### PR TITLE
Cherry-picked height fix for Bootstrap 3.2.0: https://github.com/sliptre...

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bootstrap-tokenfield"]
 	path = lib/bootstrap-tokenfield
-	url = https://github.com/sliptree/bootstrap-tokenfield
+	url = https://github.com/olegus8/bootstrap-tokenfield


### PR DESCRIPTION
Hey, thanks for updating to the latest upstream version!

My old [upstream PR](https://github.com/sliptree/bootstrap-tokenfield/pull/173) still hasn't been merged. Any chance you can once again make this package point to my repo? I rebased it to the latest bootstrap-tokenfield.

Huge thanks!